### PR TITLE
Make Response::tags an Option<T>

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -36,5 +36,5 @@ pub struct Response {
     #[serde(rename="list")]
     pub definitions: Vec<Definition>,
     /// A list of tags that the word has been tagged with.
-    pub tags: Vec<String>,
+    pub tags: Option<Vec<String>>,
 }


### PR DESCRIPTION
Urbandictionary's API seems to have removed the `tags` field which causes the `Response` struct to fail deserialization as shown below with `cargo test --all-features -- --ignored` and `cargo test  -- --ignored`.

The `tags` field is changed into an `Option<Vec<String>>`.  Unsure if it will be added back later so I made it into an Option instead of just removing it.

```text
running 2 tests
test test_define ... FAILED
test test_definitions ... FAILED

failures:

---- test_define stdout ----
	thread 'test_define' panicked at 'called `Result::unwrap()` on an `Err` value: Json(Error("missing field `tags`", line: 1, column: 7459))', libcore/result.rs:945:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.

---- test_definitions stdout ----
	thread 'test_definitions' panicked at 'called `Result::unwrap()` on an `Err` value: Json(Error("missing field `tags`", line: 1, column: 7459))', libcore/result.rs:945:5
```


```text
running 2 tests
test test_define ... FAILED
test test_definitions ... FAILED

failures:

---- test_define stdout ----
	thread 'test_define' panicked at 'assertion failed: false', tests/test_hyper.rs:34:9
note: Run with `RUST_BACKTRACE=1` for a backtrace.

---- test_definitions stdout ----
	thread 'test_definitions' panicked at 'assertion failed: false', tests/test_hyper.rs:53:9
```